### PR TITLE
Railway gha build

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: bundle install
       - name: Build Static site
-        run: jekyll build -s . -d ./_site
+        run: bundle exec jekyll build -s . -d ./_site
       - name: Build DOcker image
         run: docker build -f ./Dockerfile -t ${{ github.ref_name }}-latest
       - name: Build and Publish latest Docker image

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -21,10 +21,10 @@ jobs:
         run: bundle exec jekyll build -s . -d ./_site        
       - name: Build DOcker image prod
         if: github.ref == 'refs/heads/master'  
-        run: docker build -f ./Dockerfile -t main-latest
-      - name: Build DOcker image prod
+        run: docker build -f ./Dockerfile -t main-latest .
+      - name: Build DOcker image stage
         if: github.ref != 'refs/heads/master'
-        run: docker build -f ./Dockerfile -t staging-latest
+        run: docker build -f ./Dockerfile -t staging-latest .
       - name: Build and Publish latest Docker image
         uses: VaultVulp/gp-docker-action@1.0.1
         with:

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -18,9 +18,13 @@ jobs:
       - name: Install dependencies
         run: bundle install
       - name: Build Static site
-        run: bundle exec jekyll build -s . -d ./_site
-      - name: Build DOcker image
-        run: docker build -f ./Dockerfile -t ${{ github.ref_name }}-latest
+        run: bundle exec jekyll build -s . -d ./_site        
+      - name: Build DOcker image prod
+        if: github.ref == 'refs/heads/master'  
+        run: docker build -f ./Dockerfile -t main-latest
+      - name: Build DOcker image prod
+        if: github.ref != 'refs/heads/master'
+        run: docker build -f ./Dockerfile -t staging-latest
       - name: Build and Publish latest Docker image
         uses: VaultVulp/gp-docker-action@1.0.1
         with:

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Build Static site
         run: bundle exec jekyll build -s . -d ./_site        
       - name: Build DOcker image prod
-        if: github.ref == 'refs/heads/master'  
+        # if: github.ref == 'refs/heads/master'  
         run: docker build -f ./Dockerfile -t main-latest .
-      - name: Build DOcker image stage
+      - name: Build Docker image stage
         if: github.ref != 'refs/heads/master'
         run: docker build -f ./Dockerfile -t staging-latest .
       - name: Build and Publish latest Docker image

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }} # Provide GITHUB_TOKEN to login into the GitHub Packages
           image-name: timmeeyblog # Provide only Docker image name, tag will be automatically set to latest
-          image: docker.pkg.github.com/timmeey/timmeey-about-everything/timmeeyblog:main-latest
+          image-tag: main-latest
 
       - name: Build and Publish latest STAGE Docker image
         if: github.ref != 'refs/heads/master'
@@ -34,4 +34,4 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }} # Provide GITHUB_TOKEN to login into the GitHub Packages
           image-name: timmeeyblog # Provide only Docker image name, tag will be automatically set to latest
-          image: docker.pkg.github.com/timmeey/timmeey-about-everything/timmeeyblog:stage-latest
+          image-tag: stage-latest

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,37 +1,30 @@
 name: Jekyll site CI
 
-on: [push,workflow_dispatch]
+on:
+  push:
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Pull non cached images
-      run: |
-        docker pull jekyll/builder:latest
-    - uses: satackey/action-docker-layer-caching@v0.0.11
-      # Ignore the failure of a step and avoid terminating the job.
-      continue-on-error: true
-    - name: Build Jekyll site
-      run: |
-        docker build --target builder .
-    - name: Build full image
-      run: |
-        docker build . -t timmeeyblog
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@359bebbc29cbe6c87da6bc9ea3bc930432750108
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+      - name: Install dependencies
+        run: bundle install
+      - name: Build Static site
+        run: jekyll build -s . -d ./_site
+      - name: Build DOcker image
+        run: docker build -f ./Dockerfile -t ${{ github.ref_name }}-latest
+      - name: Build and Publish latest Docker image
+        uses: VaultVulp/gp-docker-action@1.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }} # Provide GITHUB_TOKEN to login into the GitHub Packages
+          image-name: timmeeyblog # Provide only Docker image name, tag will be automatically set to latest
 
-    - name: Build and Publish latest Docker image
-      uses: VaultVulp/gp-docker-action@1.0.1
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }} # Provide GITHUB_TOKEN to login into the GitHub Packages
-        image-name: timmeeyblog # Provide only Docker image name, tag will be automatically set to latest
-
-    - name: CapRover Image Deploy
-      uses: mrfreasy/action-caprover@v2
-      with:
-        host: '${{secrets.CAPROVER_ROOT}}'
-        app: 'timmeey-about-everything'
-        token: '${{secrets.CAPROVER_BLOG_TOKEN}}'
-        image: docker.pkg.github.com/timmeey/timmeey-about-everything/timmeeyblog:latest
+        #image: docker.pkg.github.com/timmeey/timmeey-about-everything/timmeeyblog:latest

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -19,15 +19,19 @@ jobs:
         run: bundle install
       - name: Build Static site
         run: bundle exec jekyll build -s . -d ./_site        
-      - name: Build DOcker image prod
-        # if: github.ref == 'refs/heads/master'  
-        run: docker build -f ./Dockerfile -t main-latest .
-      - name: Build Docker image stage
-        if: github.ref != 'refs/heads/master'
-        run: docker build -f ./Dockerfile -t staging-latest .
-      - name: Build and Publish latest Docker image
+
+      - name: Build and Publish latest PROD Docker image
+        # if: github.ref == 'refs/heads/master'
         uses: VaultVulp/gp-docker-action@1.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }} # Provide GITHUB_TOKEN to login into the GitHub Packages
           image-name: timmeeyblog # Provide only Docker image name, tag will be automatically set to latest
-          image: docker.pkg.github.com/timmeey/timmeey-about-everything/timmeeyblog:latest
+          image: docker.pkg.github.com/timmeey/timmeey-about-everything/timmeeyblog:main-latest
+
+      - name: Build and Publish latest STAGE Docker image
+        if: github.ref != 'refs/heads/master'
+        uses: VaultVulp/gp-docker-action@1.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }} # Provide GITHUB_TOKEN to login into the GitHub Packages
+          image-name: timmeeyblog # Provide only Docker image name, tag will be automatically set to latest
+          image: docker.pkg.github.com/timmeey/timmeey-about-everything/timmeeyblog:stage-latest

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -30,5 +30,4 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }} # Provide GITHUB_TOKEN to login into the GitHub Packages
           image-name: timmeeyblog # Provide only Docker image name, tag will be automatically set to latest
-
-        #image: docker.pkg.github.com/timmeey/timmeey-about-everything/timmeeyblog:latest
+          image: docker.pkg.github.com/timmeey/timmeey-about-everything/timmeeyblog:latest

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -21,7 +21,7 @@ jobs:
         run: bundle exec jekyll build -s . -d ./_site        
 
       - name: Build and Publish latest PROD Docker image
-        # if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         uses: VaultVulp/gp-docker-action@1.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }} # Provide GITHUB_TOKEN to login into the GitHub Packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ ADD . $GAIA_HOME
 
 
 ############# ARTIFACT PART #############
-COPY  --from=builder /usr/local/gaia/_site/ /usr/share/nginx/html/
+COPY  ./_site/ /usr/share/nginx/html/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,10 @@
-############# SETUP DEPENDENCIES #############
-FROM jekyll/builder:latest AS builder
+FROM nginx:alpine
+
 ENV GAIA_HOME=/usr/local/gaia/
 RUN mkdir -p $GAIA_HOME
 WORKDIR $GAIA_HOME
-# add source
-ADD ./Gemfile $GAIA_HOME
-RUN chmod -R  777  ./
-RUN ["/bin/bash","bundle","install"]
-
-############# BUILDER PART #############
 ADD . $GAIA_HOME
 
-RUN ["/bin/bash","jekyll","build","-s",".","-d","./_site"]
 
 ############# ARTIFACT PART #############
-FROM nginx:latest
 COPY  --from=builder /usr/local/gaia/_site/ /usr/share/nginx/html/

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -1,3 +1,3 @@
 # Use the base image from GitHub package registry
-FROM docker.pkg.github.com/timmeey/timmeey-about-everything/timmeeyblog:latest
+FROM ghcr.io/timmeey/timmeey-about-everything/timmeeyblog:main-latest
 

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -1,0 +1,3 @@
+# Use the base image from GitHub package registry
+FROM docker.pkg.github.com/timmeey/timmeey-about-everything/timmeeyblog:latest
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
+gem 'jekyll'
 gem 'github-pages'
 gem 'jekyll-paginate'


### PR DESCRIPTION
Utilizes fully GH-A build pipeline and dummy docker file for railway deployment

This Changes the build pipeline to rely fully on GHA instead of GHA+Build in docker.
It builds a Docker Image and pushes it into GitHub container registry, as well as provides a second Dockerfile for deployment purposes, so services (like railway) that rely on BUILDING the Dockerfile itself, can also deploy this 